### PR TITLE
Make initialization script idempotent

### DIFF
--- a/scripts/init_hdfs.sh
+++ b/scripts/init_hdfs.sh
@@ -8,7 +8,7 @@ export HADOOP_OPTS="-Ddfs.namenode.name.dir=file:///data/hdfs/nn -Dfs.defaultFS=
 PATH=$PATH:$HADOOP_COMMON_HOME/bin
 
 log INFO "Format HDFS"
-hdfs namenode $HADOOP_OPTS -format &>/dev/null
+hdfs namenode $HADOOP_OPTS -format -nonInteractive &>/dev/null
 
 log INFO "Start namenode"
 hdfs namenode $HADOOP_OPTS &>/dev/null &


### PR DESCRIPTION
Previously the initialization script would fail trying to ask the TTY whether it *really* wanted to reformat the HDFS.  The presence of the nonInteractive flag indicates that if the HDFS is already formatted then no action should be taken.

This change is necessary for the initialization to take place in a Kubernetes InitContainer.  Unlike Docker Swarm, Kubernetes does not copy the container contents into a new volume when mounting it for the first
time, so we cannot initialize the HDFS in the image.